### PR TITLE
Slight refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 .bsp
 .vscode
 .metals
+.bloop
+project/project
+project/metals.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ project/plugins/project/
 
 .idea*
 .bsp
+.vscode
+.metals

--- a/core/src/main/scala/Logic.scala
+++ b/core/src/main/scala/Logic.scala
@@ -102,8 +102,8 @@ class ConnectionPool(r: Ref[Vector[Connection]]):
       .flatMap(conns => ZIO.foreachDiscard(conns)(conn => ZIO.logInfo(s"Closing: $conn")))
 
 object ConnectionPool:
-  lazy val live: ZLayer[Scope, Nothing, ConnectionPool] =
-    ZLayer(
+  lazy val live: ZLayer[Any, Nothing, ConnectionPool] =
+    ZLayer.scoped(
       ZIO.acquireRelease(
         Ref
           .make(Vector(Connection("conn1"), Connection("conn2"), Connection("conn3")))

--- a/core/src/main/scala/Main.scala
+++ b/core/src/main/scala/Main.scala
@@ -1,21 +1,19 @@
 import zio.{Console, Scope, ZIO, ZIOAppDefault, ZLayer}
 
 object Main extends ZIOAppDefault:
-  override def run: ZIO[Any, Any, Any] =
-    ZIO.scoped {
-      ZLayer
-        .makeSome[Scope, CarApi](
-          CarApi.live,
-          CarService.live,
-          CarRepository.live,
-          DB.live,
-          ConnectionPool.live
-        )
-        .build
-        .map(_.get[CarApi])
-        .flatMap { api =>
-          api.register("Toyota Corolla WE98765").flatMap(Console.printLine(_)) *>
-            api.register("VW Golf WN12345").flatMap(Console.printLine(_)) *>
-            api.register("Tesla").flatMap(Console.printLine(_))
-        }
-    }
+  val program =
+    for {
+      api <- ZIO.service[CarApi]
+      _ <- api.register("Toyota Corolla WE98765").debug
+      _ <- api.register("VW Golf WN12345").debug
+      _ <- api.register("Tesla").debug
+    } yield ()
+
+  override def run =
+    program.provide(
+      CarApi.live,
+      CarService.live,
+      CarRepository.live,
+      DB.live,
+      ConnectionPool.live
+    )

--- a/core/src/main/scala/Main.scala
+++ b/core/src/main/scala/Main.scala
@@ -1,7 +1,7 @@
 import zio.{Console, Scope, ZIO, ZIOAppDefault, ZLayer}
 
 object Main extends ZIOAppDefault:
-  val program =
+  val program: ZIO[CarApi, Nothing, Unit] =
     for {
       api <- ZIO.service[CarApi]
       _ <- api.register("Toyota Corolla WE98765").debug
@@ -9,7 +9,7 @@ object Main extends ZIOAppDefault:
       _ <- api.register("Tesla").debug
     } yield ()
 
-  override def run =
+  override def run: ZIO[Any, Any, Any] =
     program.provide(
       CarApi.live,
       CarService.live,


### PR DESCRIPTION
I changed the `Main` object to be slightly more "idiomatic". While there's nothing wrong with building the layer and then using it, it's more common to call `provide` on some effect.

In addition, `ZLayer.scoped` fixes the issue of scope propagation, and will acquire/release the resources with the layer's own lifecycle.

Thanks for the blog, by the way!